### PR TITLE
Fix redos

### DIFF
--- a/test.js
+++ b/test.js
@@ -73,3 +73,32 @@ exports['should keep url safe'] = function (t) {
 
   t.done();
 };
+
+exports['Not vulnerable to REDOS'] = function (t) {
+
+  var prefix, pump, suffix, nPumps, attackString; // for evil input
+  var input, actual, expect; // input to truncate()
+  var before, elapsed; // timing
+
+  /* URL_REGEX */
+  prefix = '-@w--w--';
+  pump = 'ww--';
+  suffix = '';
+  nPumps = 20000;
+
+  attackString = prefix;
+  for (var i = 0; i < nPumps; i++) {
+    attackString += pump;
+  }
+  attackString += suffix;
+
+  before = process.hrtime();
+  input = 'Hey ' + attackString;
+  actual = truncate(input, 4);
+  expect = 'Hey …';
+  t.strictEqual(expect, actual);
+  elapsed = process.hrtime(before);
+
+  t.equals(elapsed[0], 0); // Should take < 1 second
+  t.done();
+};

--- a/truncate.js
+++ b/truncate.js
@@ -7,7 +7,9 @@
     'use strict';
 
     var DEFAULT_TRUNCATE_SYMBOL = '…',
-        URL_REGEX = /(((ftp|https?):\/\/)[\-\w@:%_\+.~#?,&\/\/=]+)|((mailto:)?[_.\w-]+@([\w][\w\-]+\.)+[a-zA-Z]{2,3})/g; // Simple regexp
+        // Limit emails to no more than about 600 chars, well over the max of ~300.
+        // cf. RFC: https://www.rfc-editor.org/errata_search.php?eid=1690
+        URL_REGEX = /(((ftp|https?):\/\/)[\-\w@:%_\+.~#?,&\/\/=]+)|((mailto:)?[_.\w-]{1,300}@(.{1,300}\.)[a-zA-Z]{2,3})/g;
 
     function __appendEllipsis(string, options, content) {
         if (content.length === string.length || !options.ellipsis) {


### PR DESCRIPTION
Addresses the REDOS vulnerability in URL_REGEX that I disclosed by email.
This expands the set of things recognized as "emails", but I doubt it does so in a harmful way.