### PR TITLE
Don't retain URLs longer than 3000 chars

### DIFF
--- a/test.js
+++ b/test.js
@@ -74,6 +74,37 @@ exports['should keep url safe'] = function (t) {
   t.done();
 };
 
+exports['should cut off huge URLs for safety'] = function (t) {
+  var input, expect, actual, longString;
+  longString = "a".repeat(301);
+  input = 'Hey mailto:' + longString + '@' + longString + '.com';
+  actual = truncate(input, 5);
+  expect = 'Hey m…';
+  t.strictEqual(expect, actual);
+
+  // Just above the limit, should get chopped
+  longString = "a".repeat(3000 - 'https://'.length + 1);
+  input = 'Hey https://' + longString;
+  actual = truncate(input, 5);
+  expect = 'Hey h…';
+  t.strictEqual(expect, actual);
+
+  // Right at the limit, should be retained
+  longString = "a".repeat(3000 - 'https://'.length);
+  input = 'Hey https://' + longString;
+  actual = truncate(input, 5);
+  expect = input;
+  t.strictEqual(expect, actual);
+
+  // Still retain the long URL even if there's text after the long URL
+  input = 'Hey https://' + longString + " other text";
+  actual = truncate(input, 5);
+  expect = expect + '…'
+  t.strictEqual(expect, actual);
+
+  t.done();
+}
+
 exports['Not vulnerable to REDOS'] = function (t) {
 
   var prefix, pump, suffix, nPumps, attackString; // for evil input

--- a/truncate.js
+++ b/truncate.js
@@ -46,8 +46,8 @@
         while (matches) {
             URL_REGEX.lastIndex = content.length;
             matches = URL_REGEX.exec(string);
-
-            if (!matches || (matches.index - content.length) >= remainingLength) {
+            // Don't try to retain URLs longer than 3k chars, well over the 99th percentile of ~347
+            if (!matches || (matches.index - content.length) >= remainingLength || URL_REGEX.lastIndex >= (maxLength + 3000)) {
                 content += string.substring(content.length, maxLength);
                 return __appendEllipsis(string, options, content, maxLength);
             }


### PR DESCRIPTION
Closes #10 

I decided to put the 3000 char limit inside the if statement rather than the regex. Since the URLs don't have noticeable endings (unlike email address which end in a TLD), the regex would match the first 3000 chars of an enormous URL, retaining that part while still breaking the URL, which is probably undesirable.

Source on that 99th percentile number comes from that same dataset mentioned in 10:
```
$ cat cluster.idx | awk '{print length($1)}' | datamash perc:99 1
347
```

